### PR TITLE
Fix for GCC 5.3.1, Ubuntu 16.04 LTS, 64-bit

### DIFF
--- a/include/handystats/rapidjson/writer.h
+++ b/include/handystats/rapidjson/writer.h
@@ -164,7 +164,7 @@ protected:
 
 	//! \todo Optimization with custom double-to-string converter.
 	void WriteDouble(double d) {
-		if (isnan(d)) {
+		if (std::isnan(d)) {
 			d = 0;
 		}
 		char buffer[100];


### PR DESCRIPTION
I compile on Ubuntu 16.04 LTS 64-bit using GCC 5.3.1, GPP 2.24


Error in:


> [  3%] Building CXX object CMakeFiles/handystats.dir/src/config.cpp.o
> In file included from /builds/handystats/src/config.cpp:31:0:
> /builds/handystats/include/handystats/rapidjson/writer.h: In member function ‘void rapidjson::Writer<OutputStream, SourceEncoding, TargetEncoding, Allocator>::WriteDouble(double)’:
> /builds/handystats/include/handystats/rapidjson/writer.h:167:14: warning: there are no arguments to ‘isnan’ that depend on a template parameter, so a declaration of ‘isnan’ must be available [-fpermissive]
>    if (isnan(d)) {
>               ^
> /home/username/coca/handystats/include/handystats/rapidjson/writer.h: In instantiation of ‘void rapidjson::Writer<OutputStream, SourceEncoding, TargetEncoding, Allocator>::WriteDouble(double) [with OutputStream = rapidjson::GenericStringBuffer<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<> >; SourceEncoding = rapidjson::UTF8<>; TargetEncoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>]’:
> /builds/handystats/include/handystats/rapidjson/writer.h:49:62:   required from ‘rapidjson::Writer<OutputStream, SourceEncoding, TargetEncoding, Allocator>& rapidjson::Writer<OutputStream, SourceEncoding, TargetEncoding, Allocator>::Double(double) [with OutputStream = rapidjson::GenericStringBuffer<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<> >; SourceEncoding = rapidjson::UTF8<>; TargetEncoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>]’
> /builds/handystats/include/handystats/rapidjson/document.h:552:13:   required from ‘const rapidjson::GenericValue<Encoding, Allocator>& rapidjson::GenericValue<Encoding, Allocator>::Accept(Handler&) const [with Handler = rapidjson::Writer<rapidjson::GenericStringBuffer<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<> > >; Encoding = rapidjson::UTF8<>; Allocator = rapidjson::MemoryPoolAllocator<>]’
> /builds/handystats/src/config.cpp:199:22:   required from here
> /builds/handystats/include/handystats/rapidjson/writer.h:167:12: error: ‘isnan’ was not declared in this scope
>    if (isnan(d)) {
>             ^
> /builds/handystats/include/handystats/rapidjson/writer.h:167:12: note: suggested alternative:
> In file included from /builds/handystats/include/handystats/rapidjson/writer.h:9:0,
>                  from /builds/handystats/src/config.cpp:31:
> /usr/include/c++/5/cmath:641:5: note:   ‘std::isnan’
>      isnan(_Tp __x)
>      ^
> CMakeFiles/handystats.dir/build.make:254: recipe for target 'CMakeFiles/handystats.dir/src/config.cpp.o' failed
> make[2]: *** [CMakeFiles/handystats.dir/src/config.cpp.o] Error 1
> CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/handystats.dir/all' failed
> make[1]: *** [CMakeFiles/handystats.dir/all] Error 2
> Makefile:138: recipe for target 'all' failed
> make: *** [all] Error 2


I read this answer:


http://stackoverflow.com/a/18129007


> It depends on which header you include. If you include the C header <math.h> (which is part of C++, albeit marked as deprecated), then you can use the unqualified C functions, like isnan. If you on the other hand include the C++ header <cmath>, you are only guaranteed that it brings all the functions from <math.h> into the std namespace and thus you have to properly qualify them, like std::isnan (or use some kind of using directive). Unfortunately an implementation is allowed but not required to bring those functions into the global namespace, too, when including <cmath> (and thus it is one of the many "works on my machine"-incidences of C++ and the reason why many people write code like you just tried to compile unsuccessfully).
> 
> So to sum up: Either include <math.h> and use isnan or include <cmath> and use std::isnan, everything else is non-portable. Of course all this applies to any other C header and its respective C++ version, too.
> 
> EDIT: It should be noted though, that this particular function isnan is only supported since C++11 and wasn't available in C++98 at all (which may be part of your confusion). But this doesn't change anything in this situation because in C++98 neither <cmath> nor <math.h> (which was the actual C89/C90 header back then and not the C99 header that C++11 includes) had this function, since they're always in-sync. So what this library from your question maybe tried was to use C++98 while taking the isnan function from a different C99 implementation (which isn't a particularly good idea, as it might conflict with the C89/C90 parts of the C++ implementation, never even tried this though).
> 

I added "std::" prefix to isnan call. Compilation is successfully.

Attention!

It may be incompatible with older versions of the compiler.