### PR TITLE
config: Show proper traceback on invalid tag in pattern spec

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -59,7 +59,7 @@ static void process_message_queue() {
 	events::delete_event_message(message);
 }
 
-static void run_processor() {
+static void run_processor() noexcept {
 	char thread_name[16];
 	memset(thread_name, 0, sizeof(thread_name));
 


### PR DESCRIPTION
Pattern settings blocks are parsed and verified late, long after initial call to `HANDY_CONFIG_*`, and this happens in the context of the core (background) thread. If there would happen an error in a tag name then configuration processing function will raise `invalid_tag_error`, which in context of the core thread is unexpected and will lead to `std::terminate` call.

But that is not the main problem here. Main problem is that user have no means to find a reason to this termination because gcc's implementation of std::thread blocks propagation of exceptions from thread main function, effectively hiding an original traceback/exception location [1].

Supposed fix, for now, is to use `noexcept` on the thread main function. Its not general enough but valid for this library. Proper fix will come in gcc v8.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55917

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yandex/handystats/11)
<!-- Reviewable:end -->
