### PR TITLE
Reduce CPU consumption and overhead of handystat in idle state

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -73,7 +73,7 @@ static void run_processor() noexcept {
 		}
 		else {
 			last_message_timestamp = std::max(last_message_timestamp, chrono::tsc_clock::now());
-			std::this_thread::sleep_for(std::chrono::microseconds(10));
+			std::this_thread::sleep_for(std::chrono::microseconds(1000));
 		}
 
 		metrics_dump::update(chrono::tsc_clock::now(), last_message_timestamp);


### PR DESCRIPTION
On my setup, handystat uses around 7% CPU when idling.
I profiled the handystat thread and noticed that the massive context switches related to the short sleep (10µs) were actually causing this high CPU usage.
```$ perf stat -t 24472 sleep 2
 Performance counter stats for thread id '24472':
        275,687107      task-clock (msec)         #    0,138 CPUs utilized          
            25 474      context-switches          #    0,092 M/sec                  
               180      cpu-migrations            #    0,653 K/sec                    (99,98%)
                 0      page-faults               #    0,000 K/sec                    (99,98%)
       159 453 219      cycles                    #    0,578 GHz                    
        99 894 781      stalled-cycles-frontend   #   62,65% frontend cycles idle   
       140 009 919      instructions              #    0,88  insn per cycle         
                                                  #    0,71  stalled cycles per insn
        27 602 034      branches                  #  100,121 M/sec                  
           394 301      branch-misses             #    1,43% of all branches
```
and
```
[ perf record: Captured and wrote 0.079 MB perf.data (1388 samples) ]
  39,37%  handystats  [kernel.vmlinux]    [k] __bpf_prog_run
  22,97%  handystats  [kernel.vmlinux]    [k] __sched_text_start
  22,61%  handystats  [kernel.vmlinux]    [k] hrtimer_nanosleep
  11,54%  handystats  [kernel.vmlinux]    [k] dequeue_entity
   1,87%  handystats  [kernel.vmlinux]    [k] native_write_msr
```
I assume handystat is targetting applications that look for low overhead of statistics collection even in case of idle activity, which means the idle sleep should be less costly.