### PR TITLE
metrics_dump: add attribute with configured dump-interval value

### DIFF
--- a/src/metrics_dump.cpp
+++ b/src/metrics_dump.cpp
@@ -180,6 +180,23 @@ create_dump()
 		// metrics_dump.dump_time will be added later
 	}
 
+	// config
+	{
+		auto dump_interval = config::metrics_dump_opts.interval;
+
+		metrics::attribute dump_interval_attr;
+		dump_interval_attr.set(
+				chrono::duration::convert_to(chrono::time_unit::MSEC, dump_interval).count()
+			);
+
+		new_dump->insert(
+				std::pair<std::string, metrics::metric_variant>(
+					"handystats.config.dump_interval",
+					dump_interval_attr
+					)
+				);
+	}
+
 	{
 		// NOTE: possible call chrono::system_clock::now()
 		chrono::time_point system_timestamp =


### PR DESCRIPTION
Explicit knowledge about dump-interval value can help in making external tooling down the pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yandex/handystats/14)
<!-- Reviewable:end -->
