### PR TITLE
Fix Valgrind reporting memory leaks

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -7,7 +7,7 @@ We see **metrics** and **statistics** on different levels of abstraction.
 While *statistics* (in particular, :ref:`incremental-statistics`) characterize time-stamped data series whitout any relations with another series,
 *metrics* are data sources for statistics and can aggragate related statistics.
 
-**Mertics** are an interface to represent internal processes and inherent data in user's application.
+**Metrics** are an interface to represent internal processes and inherent data in user's application.
 And metrics' collected statistics provide user an opportunity to understand application's state.
 
 Examples of metrics presented in handystats library are:

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -32,6 +32,15 @@
 
 #include "config_impl.hpp"
 
+namespace {
+
+rapidjson::Document& get_source() {
+	static rapidjson::Document source;
+	return source;
+}
+
+} // namespace
+
 namespace handystats { namespace config {
 
 /*
@@ -154,8 +163,6 @@ std::vector<
 >
 pattern_opts;
 
-std::shared_ptr<rapidjson::Document> source(new rapidjson::Document());
-
 static void reset() {
 	statistics_opts = statistics();
 
@@ -167,7 +174,8 @@ static void reset() {
 	core_opts = core();
 
 	pattern_opts.clear();
-	source.reset(new rapidjson::Document());
+	rapidjson::Document doc;
+	get_source().Swap(doc);
 }
 
 __attribute__((constructor(300)))
@@ -194,7 +202,7 @@ bool config_json(const char* config_data) {
 		return true;
 	}
 
-	rapidjson::Document& cfg = *config::source.get();
+	rapidjson::Document& cfg = get_source();
 
 	cfg.Parse<0>(config_data);
 	if (cfg.HasParseError()) {


### PR DESCRIPTION
Hello,

Let us consider the following program:
```
#include <string>
#include <handystats/core.hpp>

namespace {

const std::string kJsonConfig =
"{\
    \"metrics\": {\
        \"timer\": {\
            \"idle-timeout\": 500000,\
            \"tags\": [\"min\",\"max\",\"avg\",\"count\",\"moving-avg\",\"moving-count\"]\
        },\
        \"gauge\": {\
            \"tags\": [\"min\",\"max\",\"avg\",\"moving-avg\"]\
        },\
        \"counter\": {\
        }\
    },\
    \"metrics-dump\": {\
        \"interval\": 10000\
    },\
    \"json-dump\": {\
        \"interval\": 10000\
    }, \
    \"statistics\": {\
        \"moving-interval\": 3600000,\
        \"histogram-bins\": 720\
    }\
}";

} /* namespace  */

int main(int argc, const char *argv[])
{
    HANDY_CONFIG_JSON(kJsonConfig.c_str());
    HANDY_INIT();
    HANDY_FINALIZE();
    return 0;
}
```
Running Valgrind on this leads definitive memory lost.

> ==3008== Memcheck, a memory error detector
> ==3008== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
> ==3008== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
> ==3008== Command: ./a.out
> ==3008==
> ==3008==
> ==3008== HEAP SUMMARY:
> ==3008==     in use at exit: 65,713 bytes in 5 blocks
> ==3008==   total heap usage: 50 allocs, 45 frees, 358,863 bytes allocated
> ==3008==
> ==3008== 65,713 (24 direct, 65,689 indirect) bytes in 1 blocks are definitely lost in loss record 5 of 5
> ==3008==    at 0x4C2C25F: operator new(unsigned long) (vg_replace_malloc.c:334)
> ==3008==    by 0x4E4C0C4: __shared_count<rapidjson::GenericDocument<rapidjson::UTF8<> >*> (shared_ptr_base.h:584)
> ==3008==    by 0x4E4C0C4: __shared_count<rapidjson::GenericDocument<rapidjson::UTF8<> >*> (shared_ptr_base.h:595)
> ==3008==    by 0x4E4C0C4: __shared_ptr<rapidjson::GenericDocument<rapidjson::UTF8<> > > (shared_ptr_base.h:1079)
> ==3008==    by 0x4E4C0C4: reset<rapidjson::GenericDocument<rapidjson::UTF8<> > > (shared_ptr_base.h:1243)
> ==3008==    by 0x4E4C0C4: handystats::config::reset() (config.cpp:172)
> ==3008==    by 0x400F899: call_init.part.0 (dl-init.c:72)
> ==3008==    by 0x400F9AA: call_init (dl-init.c:30)
> ==3008==    by 0x400F9AA: _dl_init (dl-init.c:120)
> ==3008==    by 0x4000C59: ??? (in /lib/x86_64-linux-gnu/ld-2.24.so)
> ==3008==
> ==3008== LEAK SUMMARY:
> ==3008==    definitely lost: 24 bytes in 1 blocks
> ==3008==    indirectly lost: 65,689 bytes in 4 blocks
> ==3008==      possibly lost: 0 bytes in 0 blocks
> ==3008==    still reachable: 0 bytes in 0 blocks
> ==3008==         suppressed: 0 bytes in 0 blocks
> ==3008==
> ==3008== For counts of detected and suppressed errors, rerun with: -v
> ==3008== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)

Tell me if this needs to be reworked.
Stac