### PR TITLE
Fix memory leak json_value

### DIFF
--- a/src/json/attribute_json_writer.hpp
+++ b/src/json/attribute_json_writer.hpp
@@ -35,7 +35,11 @@ namespace handystats { namespace json {
 template<typename Allocator>
 inline void write_to_json_value(const metrics::attribute* const obj, rapidjson::Value* json_value, Allocator& allocator) {
 	if (!obj) {
-		json_value = new rapidjson::Value();
+		if (!json_value) {
+			json_value = new rapidjson::Value();
+		} else {
+			json_value->SetNull();
+		}
 		return;
 	}
 

--- a/src/json/counter_json_writer.hpp
+++ b/src/json/counter_json_writer.hpp
@@ -33,7 +33,11 @@ namespace handystats { namespace json {
 template<typename Allocator>
 inline void write_to_json_value(const metrics::counter* const obj, rapidjson::Value* json_value, Allocator& allocator) {
 	if (!obj) {
-		json_value = new rapidjson::Value();
+		if (!json_value) {
+			json_value = new rapidjson::Value();
+		} else {
+			json_value->SetNull();
+		}
 		return;
 	}
 

--- a/src/json/gauge_json_writer.hpp
+++ b/src/json/gauge_json_writer.hpp
@@ -33,7 +33,11 @@ namespace handystats { namespace json {
 template<typename Allocator>
 inline void write_to_json_value(const metrics::gauge* const obj, rapidjson::Value* json_value, Allocator& allocator) {
 	if (!obj) {
-		json_value = new rapidjson::Value();
+		if (!json_value) {
+			json_value = new rapidjson::Value();
+		} else {
+			json_value->SetNull();
+		}
 		return;
 	}
 

--- a/src/json/timer_json_writer.hpp
+++ b/src/json/timer_json_writer.hpp
@@ -33,7 +33,11 @@ namespace handystats { namespace json {
 template<typename Allocator>
 inline void write_to_json_value(const metrics::timer* const obj, rapidjson::Value* json_value, Allocator& allocator) {
 	if (!obj) {
-		json_value = new rapidjson::Value();
+		if (!json_value) {
+			json_value = new rapidjson::Value();
+		} else {
+			json_value->SetNull();
+		}
 		return;
 	}
 


### PR DESCRIPTION
Hi,

If the obj is not null, you check the json_value, if null creat new, if not null call SetObject().
```
if (!obj) {
  json_value = new rapidjson::Value();
  return;
}
if (!json_value) {
  json_value = new rapidjson::Value(rapidjson::kObjectType);
} else {
  json_value->SetObject();
}
```
But if obj null, and json_value not null, possible memory leak, because are creating a new.
```
if (!obj) {
  json_value = new rapidjson::Value();
  return;
}
```
I suggest adding a json_value check to prevent the possibility memory leak.
```
if (!obj) {
  if (!json_value) {
    json_value = new rapidjson::Value();
  } else {
    json_value->SetNull();
  }
return;
}
```